### PR TITLE
single image download in jpeg

### DIFF
--- a/src/utils/ExportHandler.ts
+++ b/src/utils/ExportHandler.ts
@@ -10,14 +10,14 @@ export function saveImage(canvas: fabric.Canvas | null): void {
 	}
 	// if (!canvas) return;
 	const dataUrl = canvas.toDataURL({
-		format: 'png',
+		format: 'jpeg',
 		multiplier: 2,
 		quality: 1.0,
 	});
 
 	const link = document?.createElement('a');
 	link.href = dataUrl;
-	link.download = 'canvas-export.png';
+	link.download = 'canvas-export.jpeg';
 	link.click();
 	console.log('Canvas is .', canvas);
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Changed the image export format from PNG to JPEG in the saveImage function.

<!-- Generated by sourcery-ai[bot]: end summary -->